### PR TITLE
variable declaration

### DIFF
--- a/core/crawler.py
+++ b/core/crawler.py
@@ -23,7 +23,8 @@ class LinkParser(HTMLParser):
         else:
             return "",[]
 
-def spider(url, maxPages):  
+def spider(url, maxPages):
+    links = [] 
     pagesToVisit = [url]
     numberVisited = 0
     foundWord = False


### PR DESCRIPTION
Hi Americo,
I downloaded sqlfinder to test on my vm with xubuntu (Python 3.10.6)

however I was getting the error below:

![image](https://github.com/americo/sqlifinder/assets/52825808/2bd74bd6-5ffe-4401-9f8f-3651f56c96fb)


I interpreted this as the variable being used before it was declared. So I made an assignment at the beginning of the spider function in crawler.py

![image](https://github.com/americo/sqlifinder/assets/52825808/52eda242-b3f4-4343-b228-7e6c62c062ea)


I made the same change on windows (Python 3.11.2) and it also worked. The error was a little different on this python version.

![image](https://github.com/americo/sqlifinder/assets/52825808/f224d3d5-065f-470e-b876-7e416c1817b0)
